### PR TITLE
Fixes for Impersonation Policy Updates

### DIFF
--- a/docs/data-sources/access_management_snowflake_policy.md
+++ b/docs/data-sources/access_management_snowflake_policy.md
@@ -35,7 +35,7 @@ data "altr_access_management_snowflake_policy" "example" {
 - `description` (String) Description of the Snowflake access management policy.
 - `name` (String) Name of the Snowflake access management policy.
 - `policy_maintenance` (Attributes) Policy maintenance configuration. (see [below for nested schema](#nestedatt--policy_maintenance))
-- `rules` (List of Object) List of rules for the Snowflake access management policy. (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of rules for the Snowflake access management policy. (see [below for nested schema](#nestedatt--rules))
 - `updated_at` (String) Last update timestamp.
 
 <a id="nestedatt--policy_maintenance"></a>
@@ -52,66 +52,66 @@ Read-Only:
 
 Read-Only:
 
-- `access` (List of Object) (see [below for nested schema](#nestedobjatt--rules--access))
-- `actors` (List of Object) (see [below for nested schema](#nestedobjatt--rules--actors))
-- `objects` (List of Object) (see [below for nested schema](#nestedobjatt--rules--objects))
-- `tagged_objects` (List of Object) (see [below for nested schema](#nestedobjatt--rules--tagged_objects))
+- `access` (Attributes List) Access for the rule. (see [below for nested schema](#nestedatt--rules--access))
+- `actors` (Attributes List) List of actors for the rule. (see [below for nested schema](#nestedatt--rules--actors))
+- `objects` (Attributes List) List of objects for the rule. (see [below for nested schema](#nestedatt--rules--objects))
+- `tagged_objects` (Attributes List) Tagged objects for the rule. (see [below for nested schema](#nestedatt--rules--tagged_objects))
 
-<a id="nestedobjatt--rules--access"></a>
+<a id="nestedatt--rules--access"></a>
 ### Nested Schema for `rules.access`
 
 Read-Only:
 
-- `name` (String)
+- `name` (String) Name of the access permission.
 
 
-<a id="nestedobjatt--rules--actors"></a>
+<a id="nestedatt--rules--actors"></a>
 ### Nested Schema for `rules.actors`
 
 Read-Only:
 
-- `condition` (String)
-- `identifiers` (List of String)
-- `type` (String)
+- `condition` (String) Condition for the actor (e.g., equals, starts_with, ends_with).
+- `identifiers` (List of String) List of identifiers for the actor.
+- `type` (String) Type of the actor.
 
 
-<a id="nestedobjatt--rules--objects"></a>
+<a id="nestedatt--rules--objects"></a>
 ### Nested Schema for `rules.objects`
 
 Read-Only:
 
-- `condition` (String)
-- `fully_qualified_identifiers` (List of Object) (see [below for nested schema](#nestedobjatt--rules--objects--fully_qualified_identifiers))
-- `identifiers` (List of String)
-- `type` (String)
+- `condition` (String) Condition for the object (e.g., equals, starts_with, ends_with, fully_qualified).
+- `fully_qualified_identifiers` (Attributes List) List of fully qualified object reference. (see [below for nested schema](#nestedatt--rules--objects--fully_qualified_identifiers))
+- `identifiers` (List of String) List of identifiers for the object.
+- `type` (String) Type of the object (e.g., database, schema, table, view).
 
-<a id="nestedobjatt--rules--objects--fully_qualified_identifiers"></a>
+<a id="nestedatt--rules--objects--fully_qualified_identifiers"></a>
 ### Nested Schema for `rules.objects.fully_qualified_identifiers`
 
 Read-Only:
 
-- `database` (String)
-- `schema` (String)
-- `table` (String)
-- `view` (String)
+- `database` (String) Database name.
+- `schema` (String) Schema name.
+- `table` (String) Table name.
+- `view` (String) View name.
 
 
 
-<a id="nestedobjatt--rules--tagged_objects"></a>
+<a id="nestedatt--rules--tagged_objects"></a>
 ### Nested Schema for `rules.tagged_objects`
 
 Read-Only:
 
-- `check_against` (List of String)
-- `tag_condition` (String)
-- `tagged_with` (List of Object) (see [below for nested schema](#nestedobjatt--rules--tagged_objects--tagged_with))
+- `check_against` (List of String) Check against these objects.
+- `tag_condition` (String) Tag condition for the tagged objects.
+- `tagged_with` (Attributes List) Tagged with these object references. (see [below for nested schema](#nestedatt--rules--tagged_objects--tagged_with))
 
-<a id="nestedobjatt--rules--tagged_objects--tagged_with"></a>
+<a id="nestedatt--rules--tagged_objects--tagged_with"></a>
 ### Nested Schema for `rules.tagged_objects.tagged_with`
 
 Read-Only:
 
-- `database` (String)
-- `name` (String)
-- `schema` (String)
-- `value` (String)
+- `database` (String) Database name.
+- `name` (String) Tag name.
+- `schema` (String) Schema name.
+- `value` (String) Tag value.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -104,6 +104,14 @@ func handleAPIResponse(resp *http.Response, v interface{}) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		resBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error reading response body: %w", err)
+		}
+		fmt.Printf("API Response Body Raw: %s\n", string(resBytes)) // Debugging line to print the response body
+
+		// Reset resp.Body so it can be read again by json.NewDecoder below
+		resp.Body = io.NopCloser(bytes.NewBuffer(resBytes))
 		if v != nil {
 			return json.NewDecoder(resp.Body).Decode(v)
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -108,7 +108,6 @@ func handleAPIResponse(resp *http.Response, v interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error reading response body: %w", err)
 		}
-		fmt.Printf("API Response Body Raw: %s\n", string(resBytes)) // Debugging line to print the response body
 
 		// Reset resp.Body so it can be read again by json.NewDecoder below
 		resp.Body = io.NopCloser(bytes.NewBuffer(resBytes))

--- a/internal/client/impersonation_policy.go
+++ b/internal/client/impersonation_policy.go
@@ -102,12 +102,24 @@ func (c *Client) UpdateImpersonationPolicy(policyID string, input UpdateImperson
 		return nil, fmt.Errorf("failed to update impersonation policy: %w", err)
 	}
 
-	var policy ImpersonationPolicy
-	if err := handleAPIResponse(resp, &policy); err != nil {
+	var response struct {
+		Data struct {
+			Policy   ImpersonationPolicy `json:"policy"`
+			PolicyID string              `json:"policy_id"`
+		} `json:"data"`
+	}
+
+	// var policy ImpersonationPolicy
+	if err := handleAPIResponse(resp, &response); err != nil {
 		return nil, fmt.Errorf("failed to update impersonation policy: %w", err)
 	}
 
-	return &policy, nil
+	// We need to set this because the API doesn't return it in the policy object
+	response.Data.Policy.ID = response.Data.PolicyID
+
+	fmt.Printf("UpdateImpersonationPolicy API response policy: %+v\n", response) // Debugging line to print the updated policy
+
+	return &response.Data.Policy, nil
 }
 
 // DeleteImpersonationPolicy deletes an impersonation policy

--- a/internal/client/impersonation_policy.go
+++ b/internal/client/impersonation_policy.go
@@ -117,8 +117,6 @@ func (c *Client) UpdateImpersonationPolicy(policyID string, input UpdateImperson
 	// We need to set this because the API doesn't return it in the policy object
 	response.Data.Policy.ID = response.Data.PolicyID
 
-	fmt.Printf("UpdateImpersonationPolicy API response policy: %+v\n", response) // Debugging line to print the updated policy
-
 	return &response.Data.Policy, nil
 }
 

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -3,6 +3,8 @@
 
 package client
 
+import "encoding/json"
+
 // Sidecar structures
 type Sidecar struct {
 	ID                       string     `json:"id"`
@@ -131,4 +133,9 @@ type GetRepoBindOutput struct {
 type ListBindingsOutput struct {
 	RepoBindings []RepoSidecarBinding `json:"repo_bindings"`
 	ContiguousID string               `json:"contiguous_id"`
+}
+
+type APIResponse struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }

--- a/internal/service/policy/access_management_oltp_policy_data_source_test.go
+++ b/internal/service/policy/access_management_oltp_policy_data_source_test.go
@@ -81,7 +81,7 @@ resource "altr_access_management_oltp_policy" "test" {
     type = %[7]q
     actors = [{
         type = %[8]q,
-        identifiers = [%[9]q, %[9]q], // Duplicate identifiers
+        identifiers = [%[9]q],
         condition = %[10]q,
     }],
     objects = [{

--- a/internal/service/policy/impersonation_policy.go
+++ b/internal/service/policy/impersonation_policy.go
@@ -277,16 +277,12 @@ func (r *ImpersonationPolicyResource) Update(ctx context.Context, req resource.U
 	// Convert rules from Terraform model to client model
 	rules := convertRulesFromTerraform(plan.Rules)
 
-	fmt.Printf("UpdateImpersonationPolicy plan rules: %+v\n", rules)
-
 	// Create the input for the API call
 	input := client.UpdateImpersonationPolicyInput{
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueString(),
 		Rules:       rules,
 	}
-
-	fmt.Printf("UpdateImpersonationPolicy input: %+v\n", input)
 
 	// Call the API to update the impersonation policy
 	policy, err := r.client.UpdateImpersonationPolicy(state.ID.ValueString(), input)
@@ -299,12 +295,8 @@ func (r *ImpersonationPolicyResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	fmt.Printf("UpdateImpersonationPolicy response policy: %+v\n", policy)
-
 	// Map response to the model
 	r.mapPolicyToModel(policy, &plan)
-
-	fmt.Printf("UpdateImpersonationPolicy plan after mapping: %+v\n", plan)
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/internal/service/policy/impersonation_policy.go
+++ b/internal/service/policy/impersonation_policy.go
@@ -277,12 +277,16 @@ func (r *ImpersonationPolicyResource) Update(ctx context.Context, req resource.U
 	// Convert rules from Terraform model to client model
 	rules := convertRulesFromTerraform(plan.Rules)
 
+	fmt.Printf("UpdateImpersonationPolicy plan rules: %+v\n", rules)
+
 	// Create the input for the API call
 	input := client.UpdateImpersonationPolicyInput{
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueString(),
 		Rules:       rules,
 	}
+
+	fmt.Printf("UpdateImpersonationPolicy input: %+v\n", input)
 
 	// Call the API to update the impersonation policy
 	policy, err := r.client.UpdateImpersonationPolicy(state.ID.ValueString(), input)
@@ -295,8 +299,12 @@ func (r *ImpersonationPolicyResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
+	fmt.Printf("UpdateImpersonationPolicy response policy: %+v\n", policy)
+
 	// Map response to the model
 	r.mapPolicyToModel(policy, &plan)
+
+	fmt.Printf("UpdateImpersonationPolicy plan after mapping: %+v\n", plan)
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)

--- a/internal/service/policy/impersonation_policy_data_source.go
+++ b/internal/service/policy/impersonation_policy_data_source.go
@@ -49,7 +49,7 @@ func (d *ImpersonationPolicyDataSource) Schema(ctx context.Context, req datasour
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[a-zA-Z0-9_-]+$`),
+						regexp.MustCompile(`^[a-zA-Z0-9_#-]+$`),
 						"must be a valid policy ID",
 					),
 				},

--- a/internal/service/policy/impersonation_policy_test.go
+++ b/internal/service/policy/impersonation_policy_test.go
@@ -82,6 +82,47 @@ func TestAccImpersonationPolicyResource_disappears(t *testing.T) {
 	})
 }
 
+func TestAccImpersonationPolicyResource_updateActors(t *testing.T) {
+	resourceName := "altr_impersonation_policy.test"
+	policyName := acctest.RandomWithPrefixUnderscoreMaxLength("impersonation_policy", 32)
+	repoName := acctest.RandomWithPrefixUnderscoreMaxLength("repo", 32)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckImpersonationPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basic(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basicTwoActors(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckImpersonationPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -198,6 +239,35 @@ resource "altr_impersonation_policy" "test" {
 `, policyName, repoName)
 }
 
+func testAccImpersonationPolicyResourceConfig_basicTwoActors(policyName, repoName string) string {
+	return fmt.Sprintf(`
+resource "altr_impersonation_policy" "test" {
+  name        = %[1]q
+  description = "Test impersonation policy"
+  repo_name   = %[2]q
+
+  rules = [
+    {
+      actors = [
+        {
+          type        = "idp_user"
+          identifiers = ["user1@example.com", "user2@example.com"]
+          condition   = "equals"
+        }
+      ]
+      targets = [
+        {
+          type        = "repo_user"
+          identifiers = ["target_user"]
+          condition   = "equals"
+        }
+      ]
+    }
+  ]
+}
+`, policyName, repoName)
+}
+
 func testAccImpersonationPolicyResourceConfig_invalidRules(policyName, repoName string) string {
 	return fmt.Sprintf(`
 resource "altr_impersonation_policy" "test" {
@@ -225,4 +295,39 @@ resource "altr_impersonation_policy" "test" {
   ]
 }
 `, policyName, repoName)
+}
+
+func testAccCheckImpersonationPolicy_updateActors(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Impersonation Policy ID is set")
+		}
+
+		// Create a new client for testing
+		conn, err := client.NewClient(
+			"52f415a4-de37-498b-a38f-c0a3b474730e",
+			"ALTR-AB5C87D832F84A95BEA9F2DC14202A5A",
+			"c366815e615df0f3500316295f4d0550b1dcf9b3f659a9f2a3545994c946ba24",
+			"https://52f415a4-de37-498b-a38f-c0a3b474730e.altrnet-trunnion1.568950776381.sandbox.ct.dev.altr.com",
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create test client: %w", err)
+		}
+
+		policy, err := conn.GetImpersonationPolicy(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if policy == nil {
+			return fmt.Errorf("Impersonation Policy not found")
+		}
+
+		return nil
+	}
 }

--- a/internal/service/policy/impersonation_policy_test.go
+++ b/internal/service/policy/impersonation_policy_test.go
@@ -123,6 +123,92 @@ func TestAccImpersonationPolicyResource_updateActors(t *testing.T) {
 	})
 }
 
+func TestAccImpersonationPolicyResource_updateDescriptionAddTargets(t *testing.T) {
+	resourceName := "altr_impersonation_policy.test"
+	policyName := acctest.RandomWithPrefixUnderscoreMaxLength("impersonation_policy", 32)
+	repoName := acctest.RandomWithPrefixUnderscoreMaxLength("repo", 32)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckImpersonationPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basic(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basicNewTargetsAndDesc(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccImpersonationPolicyResource_updateDescriptionRemoveActorsTargets(t *testing.T) {
+	resourceName := "altr_impersonation_policy.test"
+	policyName := acctest.RandomWithPrefixUnderscoreMaxLength("impersonation_policy", 32)
+	repoName := acctest.RandomWithPrefixUnderscoreMaxLength("repo", 32)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckImpersonationPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basicNewTargetsAndDesc(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.actors.0.identifiers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.targets.#", "2"),
+				),
+			},
+			{
+				Config: testAccImpersonationPolicyResourceConfig_basic(policyName, repoName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImpersonationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "repo_name", repoName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.actors.0.identifiers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.targets.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckImpersonationPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -259,6 +345,40 @@ resource "altr_impersonation_policy" "test" {
         {
           type        = "repo_user"
           identifiers = ["target_user"]
+          condition   = "equals"
+        }
+      ]
+    }
+  ]
+}
+`, policyName, repoName)
+}
+
+func testAccImpersonationPolicyResourceConfig_basicNewTargetsAndDesc(policyName, repoName string) string {
+	return fmt.Sprintf(`
+resource "altr_impersonation_policy" "test" {
+  name        = %[1]q
+  description = "Updated description"
+  repo_name   = %[2]q
+
+  rules = [
+    {
+      actors = [
+        {
+          type        = "idp_user"
+          identifiers = ["user1@example.com", "user2@example.com"]
+          condition   = "equals"
+        }
+      ]
+      targets = [
+        {
+          type        = "repo_user"
+          identifiers = ["target_user"]
+          condition   = "equals"
+        },
+        {
+          type        = "repo_user"
+          identifiers = ["target_user2"]
           condition   = "equals"
         }
       ]

--- a/internal/service/policy/impersonation_policy_test.go
+++ b/internal/service/policy/impersonation_policy_test.go
@@ -416,38 +416,3 @@ resource "altr_impersonation_policy" "test" {
 }
 `, policyName, repoName)
 }
-
-func testAccCheckImpersonationPolicy_updateActors(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Impersonation Policy ID is set")
-		}
-
-		// Create a new client for testing
-		conn, err := client.NewClient(
-			"52f415a4-de37-498b-a38f-c0a3b474730e",
-			"ALTR-AB5C87D832F84A95BEA9F2DC14202A5A",
-			"c366815e615df0f3500316295f4d0550b1dcf9b3f659a9f2a3545994c946ba24",
-			"https://52f415a4-de37-498b-a38f-c0a3b474730e.altrnet-trunnion1.568950776381.sandbox.ct.dev.altr.com",
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create test client: %w", err)
-		}
-
-		policy, err := conn.GetImpersonationPolicy(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if policy == nil {
-			return fmt.Errorf("Impersonation Policy not found")
-		}
-
-		return nil
-	}
-}

--- a/internal/service/repo/repo_sidecar_binding_test.go
+++ b/internal/service/repo/repo_sidecar_binding_test.go
@@ -546,58 +546,6 @@ resource "altr_repo_sidecar_binding" "test" {
 `, sidecarName, sidecarHostname, sidecarPubKey1, repoName, repoType, repoHostname, repoPort, listenerPort, listenerDatabaseType, listenerAdvertisedVersion)
 }
 
-func testAccCheckSidecarDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		// Create a new client for testing
-		conn, err := client.NewClient(
-			acctest.TestGetEnv("ALTR_ORG_ID", "test-org"),
-			acctest.TestGetEnv("ALTR_API_KEY", "test-key"),
-			acctest.TestGetEnv("ALTR_SECRET", "test-secret"),
-			acctest.TestGetEnv("ALTR_BASE_URL", ""),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create test client: %w", err)
-		}
-
-		return conn.DeleteSidecar(rs.Primary.ID)
-	}
-}
-
-func testAccCheckSidecarListenerDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		// Parse the ID to get sidecar_id and port
-		sidecarID := rs.Primary.Attributes["sidecar_id"]
-		portStr := rs.Primary.Attributes["port"]
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			return fmt.Errorf("Invalid port in state: %s", portStr)
-		}
-
-		// Create a new client for testing
-		conn, err := client.NewClient(
-			acctest.TestGetEnv("ALTR_ORG_ID", "test-org"),
-			acctest.TestGetEnv("ALTR_API_KEY", "test-key"),
-			acctest.TestGetEnv("ALTR_SECRET", "test-secret"),
-			acctest.TestGetEnv("ALTR_BASE_URL", ""),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create test client: %w", err)
-		}
-
-		return conn.DeregisterSidecarListener(sidecarID, port)
-	}
-}
-
 var pubKeyExample1 = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp/TpUtMCmMLzQ+vTzuel
 XudSzqzsgjEj7dWrpNgY+fwo8r6oVx19pDbeNATlCMrmQM942aGmL2kdBhhPrZuC
@@ -608,6 +556,7 @@ RF5rhiJNZR6dwdftOeHzoQiLHL4r/VsJ7PpMycjdtaVgPnv30JMnkAQTP6m9c+/H
 +wIDAQAB
 -----END PUBLIC KEY-----`
 
+// nolint: unused
 var pubKeyExample2 = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzEyEtWdjYF8AnUnbrczr
 FZBarvdu/urMLvGQ6x9D6+AN8RrdHj5GV5+Bp17MHaceZTLlvra1x2LSaXlQhnro


### PR DESCRIPTION
### This MR does the following:
- Fixes Impersonation Policy Resources failing to support being changed/updated
- Fixes Impersonation Policy Data Sources not allowing properly formed policy ids to be provided (the regex would always deny `IMPERSONATION#5ea1b041-c9a5-480a-5f55-5a5d156dd5555` due to the '#')
- Fixes malformed OLTP Data Source test 